### PR TITLE
Add agent instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ install finishes. A pre-existing `~/.dotfiles` is moved aside to
 
 After installation, you may need to:
 - Restart your terminal for zsh configuration changes
+- Restart Claude Code for agent environment changes
 - Restart Finder for file system preference changes
 - Restart SystemUIServer for UI preference changes
 - Add Homebrew to your shell profile if not already present
@@ -47,6 +48,7 @@ After installation, you may need to:
 
 #### **Core System**
 - **Zsh Configuration**: Custom shell setup with aliases, functions, and prompt
+- **AI Agent Configuration**: Shared Codex/Claude instructions and Claude Code shell environment
 - **macOS Optimization**: Comprehensive system preferences and configurations
 - **Safe Installation**: Automatic backup system with timestamped directories
 - **Easy Updates**: Simple update process for seamless maintenance

--- a/src/agents/README.md
+++ b/src/agents/README.md
@@ -1,0 +1,57 @@
+# AI Agent Configuration
+
+This component installs shared instructions and a non-interactive shell
+environment for local AI coding agents.
+
+## Installed files
+
+- `~/.agents/instructions.md` → machine-local rules for AI agents
+- `~/.agents/env.zsh` → shell configuration used by Claude Code commands
+- `~/.codex/AGENTS.md` → shared instructions
+- `~/.claude/CLAUDE.md` → shared instructions
+
+The setup also adds this value to `~/.claude/settings.json` while preserving
+all other Claude settings:
+
+```json
+{
+  "env": {
+    "CLAUDE_ENV_FILE": "/Users/mark.hess/.agents/env.zsh"
+  }
+}
+```
+
+Claude Code sources `CLAUDE_ENV_FILE` before every Bash-tool command. Codex
+already loads the interactive Zsh configuration and only uses the shared
+instructions file.
+
+## Machine-local instructions
+
+The repository tracks only `instructions.example.md`. On first setup it is
+copied to `~/.agents/instructions.md`; subsequent runs never overwrite that
+local file. Customize it independently on each computer. Codex and Claude link
+their global instruction entry points to the local file.
+
+## Agent shell environment
+
+`env.zsh` loads the command-useful files from the Zsh configuration:
+
+- `exports.zsh` for environment variables, PATH, and asdf
+- `aliases.zsh` for command aliases
+- `functions.zsh` for reusable shell functions
+- `private.zsh` for private environment variables and commands
+
+It intentionally skips `prompt.zsh`, Oh My Zsh initialization, and completion
+scripts because those are interactive terminal features.
+
+## Setup
+
+The main dotfiles installer offers this component automatically. It can also be
+run independently:
+
+```bash
+./src/agents/setup.sh
+```
+
+Conflicting files and Claude settings are backed up under
+`~/.dotfiles_backup/<timestamp>/agents/` before replacement.

--- a/src/agents/env.zsh
+++ b/src/agents/env.zsh
@@ -1,0 +1,11 @@
+# Shared shell environment for AI agents.
+# Load command-useful configuration without interactive prompts or completions.
+
+if [[ -z "${MARKHESS_AGENT_ENV_LOADED:-}" ]]; then
+    MARKHESS_AGENT_ENV_LOADED=1
+
+    [ -f "$HOME/.zsh/exports.zsh" ]   && source "$HOME/.zsh/exports.zsh"
+    [ -f "$HOME/.zsh/aliases.zsh" ]   && source "$HOME/.zsh/aliases.zsh"
+    [ -f "$HOME/.zsh/functions.zsh" ] && source "$HOME/.zsh/functions.zsh"
+    [ -f "$HOME/.zsh/private.zsh" ]   && source "$HOME/.zsh/private.zsh"
+fi

--- a/src/agents/instructions.example.md
+++ b/src/agents/instructions.example.md
@@ -1,0 +1,6 @@
+# Global AI Agent Rules
+
+## General Behavior
+
+- Add instructions specific to this computer, its available tools, and its workflows.
+- Keep credentials and other secrets out of this file.

--- a/src/agents/setup.sh
+++ b/src/agents/setup.sh
@@ -1,0 +1,197 @@
+#!/bin/bash
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source "$SCRIPT_DIR/utils.sh"
+
+AGENTS_SOURCE_DIR="$SCRIPT_DIR/agents"
+AGENTS_TARGET_DIR="$HOME/.agents"
+AGENTS_INSTRUCTIONS_TEMPLATE="$AGENTS_SOURCE_DIR/instructions.example.md"
+CLAUDE_SETTINGS="$HOME/.claude/settings.json"
+CLAUDE_ENV_PATH="$AGENTS_TARGET_DIR/env.zsh"
+
+backup_dir=""
+
+ensure_backup_dir() {
+    if [[ -z "$backup_dir" ]]; then
+        backup_dir="$HOME/.dotfiles_backup/$(date +"%Y%m%d_%H%M%S")/agents"
+        mkdir -p "$backup_dir"
+        print_info "Backup directory: $backup_dir"
+    fi
+}
+
+backup_target() {
+    local target="$1"
+    local backup_name="$2"
+
+    if [[ -e "$target" ]] || [[ -L "$target" ]]; then
+        ensure_backup_dir
+        mv "$target" "$backup_dir/$backup_name"
+        print_warning "Backed up $target"
+    fi
+}
+
+ensure_link() {
+    local source="$1"
+    local target="$2"
+    local backup_name="$3"
+
+    if [[ -L "$target" ]] && [[ "$(readlink "$target")" == "$source" ]]; then
+        print_info "$target is already linked correctly"
+        return 0
+    fi
+
+    mkdir -p "$(dirname "$target")"
+    backup_target "$target" "$backup_name"
+    ln -s "$source" "$target"
+    print_success "Linked $target → $source"
+}
+
+ensure_local_instructions() {
+    local target="$AGENTS_TARGET_DIR/instructions.md"
+
+    mkdir -p "$AGENTS_TARGET_DIR"
+
+    if [[ -f "$target" ]] && [[ ! -L "$target" ]]; then
+        print_info "$target is local and will not be overwritten"
+        return 0
+    fi
+
+    # Migrate an older readable symlink to a machine-local regular file.
+    if [[ -L "$target" ]] && [[ -r "$target" ]]; then
+        local preserved="$AGENTS_TARGET_DIR/.instructions.md.migrate.$$"
+        cp -p "$target" "$preserved"
+        backup_target "$target" "instructions.md"
+        mv "$preserved" "$target"
+        print_success "Migrated $target to a machine-local file"
+        return 0
+    fi
+
+    if [[ -e "$target" ]] || [[ -L "$target" ]]; then
+        backup_target "$target" "instructions.md"
+    fi
+
+    cp "$AGENTS_INSTRUCTIONS_TEMPLATE" "$target"
+    print_success "Created machine-local $target from the example"
+}
+
+claude_env_value() {
+    if [[ -f "$CLAUDE_SETTINGS" ]]; then
+        /usr/bin/plutil -extract env.CLAUDE_ENV_FILE raw "$CLAUDE_SETTINGS" 2>/dev/null || true
+    fi
+}
+
+check_agents_status() {
+    local needs_update=false
+
+    local links=(
+        "$AGENTS_SOURCE_DIR/env.zsh|$AGENTS_TARGET_DIR/env.zsh"
+        "$AGENTS_TARGET_DIR/instructions.md|$HOME/.codex/AGENTS.md"
+        "$AGENTS_TARGET_DIR/instructions.md|$HOME/.claude/CLAUDE.md"
+    )
+
+    local entry source target
+    for entry in "${links[@]}"; do
+        source="${entry%%|*}"
+        target="${entry#*|}"
+        if [[ ! -L "$target" ]] || [[ "$(readlink "$target" 2>/dev/null)" != "$source" ]]; then
+            print_info "$target needs to be linked"
+            needs_update=true
+        fi
+    done
+
+    if [[ ! -f "$AGENTS_TARGET_DIR/instructions.md" ]] || [[ -L "$AGENTS_TARGET_DIR/instructions.md" ]]; then
+        print_info "$AGENTS_TARGET_DIR/instructions.md needs to be machine-local"
+        needs_update=true
+    fi
+
+    if [[ "$(claude_env_value)" != "$CLAUDE_ENV_PATH" ]]; then
+        print_info "Claude Code needs CLAUDE_ENV_FILE configured"
+        needs_update=true
+    fi
+
+    if [[ "$needs_update" == true ]]; then
+        return 1
+    fi
+
+    print_success "AI agent configuration is up to date!"
+    return 0
+}
+
+configure_claude_env() {
+    local current_value
+    current_value="$(claude_env_value)"
+
+    if [[ "$current_value" == "$CLAUDE_ENV_PATH" ]]; then
+        print_info "Claude Code already uses $CLAUDE_ENV_PATH"
+        return 0
+    fi
+
+    mkdir -p "$(dirname "$CLAUDE_SETTINGS")"
+
+    if [[ -f "$CLAUDE_SETTINGS" ]]; then
+        # macOS plutil can edit JSON but its lint mode only accepts plist
+        # formats on some releases. A no-output JSON conversion validates both.
+        if ! /usr/bin/plutil -convert json -o /dev/null "$CLAUDE_SETTINGS" >/dev/null 2>&1; then
+            print_error "Claude settings are not valid JSON: $CLAUDE_SETTINGS"
+            return 1
+        fi
+        ensure_backup_dir
+        cp -p "$CLAUDE_SETTINGS" "$backup_dir/claude-settings.json"
+        print_warning "Backed up $CLAUDE_SETTINGS"
+    else
+        printf '{}\n' > "$CLAUDE_SETTINGS"
+    fi
+
+    local env_type
+    env_type="$(/usr/bin/plutil -type env "$CLAUDE_SETTINGS" 2>/dev/null || true)"
+    if [[ -z "$env_type" ]]; then
+        /usr/bin/plutil -insert env -json '{}' "$CLAUDE_SETTINGS"
+    elif [[ "$env_type" != "dictionary" ]]; then
+        print_error "The env value in $CLAUDE_SETTINGS is not a dictionary"
+        return 1
+    fi
+
+    if /usr/bin/plutil -extract env.CLAUDE_ENV_FILE raw "$CLAUDE_SETTINGS" >/dev/null 2>&1; then
+        /usr/bin/plutil -replace env.CLAUDE_ENV_FILE -string "$CLAUDE_ENV_PATH" "$CLAUDE_SETTINGS"
+    else
+        /usr/bin/plutil -insert env.CLAUDE_ENV_FILE -string "$CLAUDE_ENV_PATH" "$CLAUDE_SETTINGS"
+    fi
+
+    print_success "Configured Claude Code to use $CLAUDE_ENV_PATH"
+}
+
+setup_agents() {
+    ensure_link "$AGENTS_SOURCE_DIR/env.zsh" "$AGENTS_TARGET_DIR/env.zsh" "env.zsh"
+    ensure_local_instructions
+    ensure_link "$AGENTS_TARGET_DIR/instructions.md" "$HOME/.codex/AGENTS.md" "codex-AGENTS.md"
+    ensure_link "$AGENTS_TARGET_DIR/instructions.md" "$HOME/.claude/CLAUDE.md" "claude-CLAUDE.md"
+    configure_claude_env
+}
+
+main() {
+    local check_only=false
+
+    if [[ "${1:-}" == "--check-only" ]]; then
+        check_only=true
+    elif [[ $# -gt 0 ]]; then
+        print_error "Usage: $0 [--check-only]"
+        exit 1
+    fi
+
+    print_info "Checking AI agent configuration..."
+    if check_agents_status; then
+        exit 0
+    fi
+
+    if [[ "$check_only" == true ]]; then
+        exit 1
+    fi
+
+    setup_agents
+    print_success "AI agent configuration setup complete!"
+    print_info "Restart Claude Code for CLAUDE_ENV_FILE to take effect"
+}
+
+main "$@"

--- a/src/main.sh
+++ b/src/main.sh
@@ -24,6 +24,11 @@ check_status() {
         return 1
     fi
 
+    if [[ ! -f "$SCRIPT_DIR/agents/setup.sh" ]]; then
+        print_error "AI agent setup script not found at $SCRIPT_DIR/agents/setup.sh"
+        return 1
+    fi
+
     if [[ ! -f "$SCRIPT_DIR/macos/setup.sh" ]]; then
         print_error "macOS setup script not found at $SCRIPT_DIR/macos/setup.sh"
         return 1
@@ -33,6 +38,13 @@ check_status() {
         print_info "Zsh configuration is up to date"
     else
         print_info "Zsh configuration updates needed"
+        needs_update=true
+    fi
+
+    if "$SCRIPT_DIR/agents/setup.sh" --check-only 2>/dev/null; then
+        print_info "AI agent configuration is up to date"
+    else
+        print_info "AI agent configuration updates needed"
         needs_update=true
     fi
 
@@ -47,7 +59,7 @@ check_status() {
         print_info "Updates needed - proceeding with installation/update"
         return 1
     else
-        print_success "Zsh configuration and macOS preferences are properly configured and up to date!"
+        print_success "Zsh, AI agent, and macOS configurations are properly configured and up to date!"
         print_info "No installation needed - everything is already set up correctly."
         return 0
     fi
@@ -88,6 +100,25 @@ execute_setup() {
         exit 1
     fi
 
+    if [[ -f "$SCRIPT_DIR/agents/setup.sh" ]]; then
+        print_section "AI Agent Configuration Setup"
+        print_info "This will install shared agent instructions and configure Claude Code's command environment."
+        print_info ""
+        "$SCRIPT_DIR/agents/setup.sh" --check-only 2>/dev/null || true
+
+        print_info ""
+        if ask_for_confirmation "Would you like to set up/update AI agent configuration?" "y"; then
+            if ! run_script_safely "$SCRIPT_DIR/agents/setup.sh"; then
+                print_warning "AI agent configuration setup failed, continuing with other sections..."
+            fi
+        else
+            print_info "Skipping AI agent configuration setup"
+        fi
+    else
+        print_error "AI agent setup script not found"
+        exit 1
+    fi
+
     if [[ -f "$SCRIPT_DIR/macos/setup.sh" ]]; then
         print_section "macOS System Preferences Setup"
         print_info "This will configure various macOS system preferences including keyboard, trackpad, UI settings, and developer tools."
@@ -123,10 +154,11 @@ show_apps() {
 main() {
     print_info "Starting dotfiles setup..."
     print_section "Dotfiles Setup Overview"
-    print_info "This setup covers three areas:"
+    print_info "This setup covers four areas:"
     print_info "1. Zsh Configuration - Shell aliases, functions, and prompt"
-    print_info "2. macOS Preferences - System settings, keyboard, trackpad, UI"
-    print_info "3. Applications - A list of apps you may want to install"
+    print_info "2. AI Agent Configuration - Shared instructions and Claude command environment"
+    print_info "3. macOS Preferences - System settings, keyboard, trackpad, UI"
+    print_info "4. Applications - A list of apps you may want to install"
     print_info ""
     print_info "You will be prompted for each major step. You can choose to complete or skip each section."
 
@@ -135,7 +167,7 @@ main() {
     check_os
 
     if check_status; then
-        print_info "Zsh and macOS already configured - no changes needed."
+        print_info "Zsh, AI agents, and macOS already configured - no changes needed."
     else
         execute_setup
     fi
@@ -149,6 +181,7 @@ main() {
     print_info ""
     print_info "Next steps:"
     print_info "- Restart your terminal to see zsh changes"
+    print_info "- Restart Claude Code to load agent environment changes"
     print_info "- Check System Preferences for macOS changes"
 }
 

--- a/src/zsh/README.md
+++ b/src/zsh/README.md
@@ -38,25 +38,24 @@ These files are installed automatically when you run the setup script. It:
 
 ### Where each file is sourced
 
-All files load from **`~/.zshrc`** only — nothing is split across `.zshenv`
-or `.zprofile`:
+All files load interactively from **`~/.zshrc`**. Command-useful files also
+load from `~/.agents/env.zsh` for configured AI agents. Nothing is loaded from
+`.zshenv` or `.zprofile`:
 
 | File | Sourced from | Why |
 |------|--------------|-----|
-| `exports.zsh` | `~/.zshrc` | Environment vars + `PATH` + asdf. |
-| `aliases.zsh` | `~/.zshrc` | Interactive-only convenience. |
-| `functions.zsh` | `~/.zshrc` | Interactive-only convenience. |
+| `exports.zsh` | `~/.zshrc`, `~/.agents/env.zsh` | Environment vars + `PATH` + asdf. |
+| `aliases.zsh` | `~/.zshrc`, `~/.agents/env.zsh` | Command aliases. |
+| `functions.zsh` | `~/.zshrc`, `~/.agents/env.zsh` | Reusable shell functions. |
 | `prompt.zsh` | `~/.zshrc` | Needs `$PROMPT` from Oh My Zsh, so it must load **after** Oh My Zsh. |
-| `private.zsh` | `~/.zshrc` | Secrets/aliases for interactive use. |
+| `private.zsh` | `~/.zshrc`, `~/.agents/env.zsh` | Private environment and commands. |
 
 The block is appended to the **end** of `~/.zshrc` so it runs after
 `source $ZSH/oh-my-zsh.sh`. It's idempotent — re-running setup detects
 the marker (`# >>> dotfiles (interactive) >>>`) and won't add duplicates.
 
-> **Note:** Because everything loads from `.zshrc`, none of it is available to
-> non-interactive shells — cron jobs, scripts, `ssh host cmd`. If you need
-> `PATH`/asdf in those contexts, source `~/.zsh/exports.zsh` directly from
-> that context.
+> **Note:** Cron jobs, scripts, and `ssh host cmd` remain unaffected. If those
+> contexts need `PATH`/asdf, source `~/.zsh/exports.zsh` directly.
 
 ## Usage
 
@@ -76,7 +75,7 @@ After manual setup, you can:
 ## Troubleshooting
 
 - **Files not loading?** Confirm the managed block exists — `grep dotfiles ~/.zshrc` — and re-run setup if missing
-- **Env vars missing in scripts/cron?** Expected — everything loads from `~/.zshrc`, which only runs for interactive shells. Source `~/.zsh/exports.zsh` explicitly if a script needs it.
+- **Env vars missing in scripts/cron?** Expected — source `~/.zsh/exports.zsh` explicitly if a script needs it. AI agent shells are configured separately by `src/agents/setup.sh`.
 - **Oh My Zsh conflicts?** The `.zshrc` block is appended after `source $ZSH/oh-my-zsh.sh`; don't move it above that line
 - **Permission issues?** Verify the symbolic links are created correctly in the `~/.zsh/` directory
 - **Prompt not working?** Make sure Oh My Zsh is installed and the theme is set in `prompt.zsh`

--- a/src/zsh/exports.zsh
+++ b/src/zsh/exports.zsh
@@ -6,9 +6,9 @@ export EDITOR="nano"
 export HOMEBREW_NO_ANALYTICS=1
 
 # asdf configuration
-# Cache the asdf prefix once. This file is sourced from ~/.zshenv (every shell),
-# so calling `brew --prefix asdf` here would fork brew on every startup. Hardcode
-# the standard Homebrew symlink instead, with an Intel fallback.
+# Cache the asdf prefix once. Calling `brew --prefix asdf` here would fork brew
+# on every interactive and agent shell startup, so use the standard Homebrew
+# symlink with an Intel fallback.
 ASDF_PREFIX="/opt/homebrew/opt/asdf"
 [[ -d "$ASDF_PREFIX" ]] || ASDF_PREFIX="/usr/local/opt/asdf"
 
@@ -19,10 +19,11 @@ fi
 
 export ASDF_DATA_DIR="${ASDF_DATA_DIR:-$HOME/.asdf}"
 
-# Add asdf shims to PATH. Guard against duplicates since .zshenv runs per shell.
-if [[ ":$PATH:" != *":$ASDF_DATA_DIR/shims:"* ]]; then
-    export PATH="$ASDF_DATA_DIR/shims:$PATH"
-fi
+# Keep asdf shims ahead of system runtimes. Remove only duplicate shim entries;
+# preserve the ordering of every other PATH entry.
+path=(${path:#"$ASDF_DATA_DIR/shims"})
+path=("$ASDF_DATA_DIR/shims" $path)
+export PATH
 
 # asdf completions (zsh-specific). fpath is set here (before .zshrc's compinit).
 if [[ -d "$ASDF_PREFIX/share/zsh/site-functions" ]]; then

--- a/src/zsh/setup.sh
+++ b/src/zsh/setup.sh
@@ -190,9 +190,6 @@ wire_zsh_sourcing() {
     # Appended to END of .zshrc so it runs AFTER oh-my-zsh
     # (prompt.zsh depends on \$PROMPT set by oh-my-zsh).
     # Listed explicitly (one line per file) so any can be commented out easily.
-    # Everything sources from .zshrc only — nothing goes through .zshenv or
-    # .zprofile, so none of this is available to non-interactive shells
-    # (cron, scripts, ssh host cmd).
     local zshrc_block="$ZSHRC_MARKER
 # Interactive config — loaded after oh-my-zsh.
 [ -f \"\$HOME/.zsh/exports.zsh\" ]   && source \"\$HOME/.zsh/exports.zsh\"


### PR DESCRIPTION
Adds shared AI agent configuration to dotfiles, including reusable instructions, a Claude Code environment file, and automated setup. Also ensures ASDF shims take precedence without reordering unrelated PATH entries.